### PR TITLE
Read hosted zones entries before deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+### Added
 
 - Add MC metadata to hosted zones.
 
-## Fixed
+### Changed
+
+- Read the cluster hosted zone only once per operation.
+
+### Fixed
 
 - Do not fail on already deleted entries.
 - Remove `alreadyExistsError` on creation/update as it's obsolete with UPSERT.

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -120,7 +120,7 @@ func (r *OpenstackClusterReconciler) reconcileNormal(ctx context.Context, cluste
 	route53Service := route53.NewService(clusterScope)
 	err := route53Service.ReconcileRoute53(ctx)
 	if route53.IsIngressNotReady(err) {
-		clusterScope.Error(err, "ingress is not ready yet, requeing")
+		clusterScope.Error(err, "ingress is not ready yet, requeuing")
 		return reconcile.Result{Requeue: true}, microerror.Mask(err)
 	} else if err != nil {
 		clusterScope.Error(err, "error creating route53")

--- a/pkg/cloud/interfaces.go
+++ b/pkg/cloud/interfaces.go
@@ -33,6 +33,8 @@ type ClusterScoper interface {
 	BaseDomain() string
 	// ClusterK8sClient returns a client to interact with the cluster.
 	ClusterK8sClient(ctx context.Context) (client.Client, error)
+	// ClusterDomain returns the cluster domain.
+	ClusterDomain() string
 	// CoreCluster returns the core cluster object.
 	CoreCluster() *capi.Cluster
 	// InfrastructureCluster returns the infrastructure cluster object.

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -120,6 +120,11 @@ func (s *ClusterScope) ClusterK8sClient(ctx context.Context) (client.Client, err
 	return s.k8sClient, nil
 }
 
+// ClusterDomain returns the cluster domain.
+func (s *ClusterScope) ClusterDomain() string {
+	return fmt.Sprintf("%s.%s", s.coreCluster.Name, s.baseDomain)
+}
+
 // Name returns the Openstack infrastructure cluster name.
 func (s *ClusterScope) Name() string {
 	return s.coreCluster.Name

--- a/pkg/cloud/services/route53/route53.go
+++ b/pkg/cloud/services/route53/route53.go
@@ -190,15 +190,11 @@ func (s *Service) changeClusterAPIRecords(ctx context.Context, hostedZoneID stri
 }
 
 func (s *Service) changeClusterIngressRecords(ctx context.Context, hostedZoneID, action string) error {
-	var ingressIP string
-	if action == actionUpsert { // Avoid looking up IP via k8s client when deleting
-		var err error
-		ingressIP, err = s.getIngressIP(ctx)
-		if err != nil {
-			return microerror.Mask(err)
-		} else if ingressIP == "" {
-			return nil
-		}
+	ingressIP, err := s.getIngressIP(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	} else if ingressIP == "" {
+		return nil
 	}
 
 	input := &route53.ChangeResourceRecordSetsInput{

--- a/pkg/cloud/services/route53/route53.go
+++ b/pkg/cloud/services/route53/route53.go
@@ -122,7 +122,6 @@ func (s *Service) deleteClusterRecords(ctx context.Context, hostedZoneID string)
 	}
 
 	for _, recordSet := range output.ResourceRecordSets {
-		// TODO extract this please
 		if strings.TrimSuffix(*recordSet.Name, ".") == s.scope.ClusterDomain() {
 			// We cannot delete those entries, they get automatically cleaned up when deleting the hosted zone
 			continue
@@ -134,10 +133,16 @@ func (s *Service) deleteClusterRecords(ctx context.Context, hostedZoneID string)
 		})
 	}
 
+	if len(recordsToDelete.ChangeBatch.Changes) == 0 {
+		// Nothing to delete
+		return nil
+	}
+
 	_, err = s.Route53Client.ChangeResourceRecordSetsWithContext(ctx, recordsToDelete)
 	if err != nil {
 		return wrapRoute53Error(err)
 	}
+
 	return nil
 }
 

--- a/pkg/cloud/services/route53/route53.go
+++ b/pkg/cloud/services/route53/route53.go
@@ -97,7 +97,7 @@ func (s *Service) describeClusterHostedZone(ctx context.Context) (string, error)
 		return "", microerror.Mask(hostedZoneNotFoundError)
 	}
 
-	if *out.HostedZones[0].Name != s.scope.ClusterDomain() {
+	if *out.HostedZones[0].Name != fmt.Sprintf("%s.", s.scope.ClusterDomain()) {
 		return "", microerror.Mask(hostedZoneNotFoundError)
 	}
 
@@ -265,7 +265,7 @@ func (s *Service) describeBaseHostedZone(ctx context.Context) (string, error) {
 		return "", microerror.Mask(hostedZoneNotFoundError)
 	}
 
-	if *out.HostedZones[0].Name != s.scope.BaseDomain() {
+	if *out.HostedZones[0].Name != fmt.Sprintf("%s.", s.scope.BaseDomain()) {
 		return "", microerror.Mask(hostedZoneNotFoundError)
 	}
 
@@ -311,7 +311,7 @@ func (s *Service) createClusterHostedZone(ctx context.Context) error {
 	now := time.Now()
 	input := &route53.CreateHostedZoneInput{
 		CallerReference: aws.String(now.UTC().String()),
-		Name:            aws.String(s.scope.ClusterDomain()),
+		Name:            aws.String(fmt.Sprintf("%s.", s.scope.ClusterDomain())),
 	}
 
 	if s.scope.ManagementCluster() != "" {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20280

1. Read hosted zone entries before deletion so that we don't have to know the API or ingress IP
2. Read the hosted zone ID just once to limit aws calls
3. Small refactorings