### PR TITLE
Remove coreCluster from scope

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -83,7 +83,6 @@ func (r *OpenstackClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Logger: log,
 
 		BaseDomain:            r.BaseDomain,
-		CoreCluster:           coreCluster,
 		InfrastructureCluster: &infraCluster,
 		ManagementCluster:     r.ManagementCluster,
 	})

--- a/pkg/cloud/interfaces.go
+++ b/pkg/cloud/interfaces.go
@@ -6,7 +6,6 @@ import (
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
 	"github.com/go-logr/logr"
 	capo "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
-	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,8 +32,6 @@ type ClusterScoper interface {
 	BaseDomain() string
 	// ClusterK8sClient returns a client to interact with the cluster.
 	ClusterK8sClient(ctx context.Context) (client.Client, error)
-	// CoreCluster returns the core cluster object.
-	CoreCluster() *capi.Cluster
 	// InfrastructureCluster returns the infrastructure cluster object.
 	InfrastructureCluster() *capo.OpenStackCluster
 	// ManagementCluster returns the name of the management cluster.


### PR DESCRIPTION
There is no need to pass the cluster in the scope - we only use it for the cluster name and we can get that from a label on the openstack cluster. 