### PR TITLE
Reduce normal reconciliation requeue time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- Reduce requeue time from five minutes to one minute to react faster to nginx IC being installed.
+
 ## [Unreleased]
 
 ## [0.4.0] - 2022-02-22

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -120,16 +120,13 @@ func (r *OpenstackClusterReconciler) reconcileNormal(ctx context.Context, cluste
 	err := route53Service.ReconcileRoute53(ctx)
 	if route53.IsIngressNotReady(err) {
 		clusterScope.Error(err, "ingress is not ready yet, requeuing")
-		return reconcile.Result{Requeue: true}, microerror.Mask(err)
+		return reconcile.Result{}, microerror.Mask(err)
 	} else if err != nil {
 		clusterScope.Error(err, "error creating route53")
 		return reconcile.Result{}, microerror.Mask(err)
 	}
 
-	return ctrl.Result{
-		Requeue:      true,
-		RequeueAfter: time.Minute * 5,
-	}, nil
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 
 func (r *OpenstackClusterReconciler) reconcileDelete(ctx context.Context, clusterScope *scope.ClusterScope) (reconcile.Result, error) {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/21120

If we install nginx IC in a WC, it could take up to five minutes for that to be detected. `cert-manager` has a timeout of 5 minutes so it's possible to get stuck. Ideally we would watch the WC and create the record immediately (or use `external-dns` to create the Service DNS record), but for now we can reduce the normal reconciliation requeue time from 5 minutes to 1 minute.